### PR TITLE
chore(deps): bump CLI from v1.1.1 to v1.1.3

### DIFF
--- a/src/main/java/io/jenkins/plugins/deepcrawltest/DeepcrawlTestBuilder.java
+++ b/src/main/java/io/jenkins/plugins/deepcrawltest/DeepcrawlTestBuilder.java
@@ -30,11 +30,11 @@ import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.Symbol;
 
 public class DeepcrawlTestBuilder extends Builder implements SimpleBuildStep {
-  private final static String CLI_VERSION = "1.1.2";
+  private final static String CLI_VERSION = "1.1.3";
   private final static String CLI_DOWNLOAD_URL = "https://github.com/deepcrawl/deepcrawl-test/releases/download/v${cliVersion}/${cliFilename}";
   private final static Map<OperatingSystem, String> CLI_FILENAME = Stream.of(
     new AbstractMap.SimpleEntry<>(OperatingSystem.LINUX, "deepcrawl-test-linux"),
-    new AbstractMap.SimpleEntry<>(OperatingSystem.MACOS, "deepcrawl-test-macos"), 
+    new AbstractMap.SimpleEntry<>(OperatingSystem.MACOS, "deepcrawl-test-macos"),
     new AbstractMap.SimpleEntry<>(OperatingSystem.WINDOWS, "deepcrawl-test-win.exe")
   ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
@@ -56,7 +56,7 @@ public class DeepcrawlTestBuilder extends Builder implements SimpleBuildStep {
     return this.userKeyId;
   }
 
-  public Secret getUserKeySecret() { 
+  public Secret getUserKeySecret() {
     return this.userKeySecret;
   }
 
@@ -80,7 +80,7 @@ public class DeepcrawlTestBuilder extends Builder implements SimpleBuildStep {
   }
 
   @Override
-  public void perform(Run<?, ?> run, FilePath workspace, EnvVars env, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {  
+  public void perform(Run<?, ?> run, FilePath workspace, EnvVars env, Launcher launcher, TaskListener listener) throws InterruptedException, IOException {
     String buildId = run.getId();
     FilePath uniqueWorkspace = workspace.child(buildId);
     OperatingSystem os = this.getOperatingSystem(workspace, launcher);


### PR DESCRIPTION
Use the latest CLI.

https://deepcrawl.atlassian.net/browse/GA-409
https://github.com/deepcrawl/deepcrawl-test/releases/tag/v1.1.3

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
