### PR TITLE
fix(cli): bump CLI from v1.1.3 to v1.1.4

### DIFF
--- a/src/main/java/io/jenkins/plugins/deepcrawltest/DeepcrawlTestBuilder.java
+++ b/src/main/java/io/jenkins/plugins/deepcrawltest/DeepcrawlTestBuilder.java
@@ -30,7 +30,7 @@ import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.Symbol;
 
 public class DeepcrawlTestBuilder extends Builder implements SimpleBuildStep {
-  private final static String CLI_VERSION = "1.1.3";
+  private final static String CLI_VERSION = "1.1.4";
   private final static String CLI_DOWNLOAD_URL = "https://github.com/deepcrawl/deepcrawl-test/releases/download/v${cliVersion}/${cliFilename}";
   private final static Map<OperatingSystem, String> CLI_FILENAME = Stream.of(
     new AbstractMap.SimpleEntry<>(OperatingSystem.LINUX, "deepcrawl-test-linux"),


### PR DESCRIPTION
Use the latest CLI.

https://lumarhq.atlassian.net/browse/GA-3450
https://github.com/deepcrawl/deepcrawl-test/releases/tag/v1.1.4

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed